### PR TITLE
[PATCH] Set SO_REUSEADDR option to avoid restart error.

### DIFF
--- a/whizzer/server.py
+++ b/whizzer/server.py
@@ -200,6 +200,7 @@ class TcpServer(SocketServer):
     def __init__(self, loop, factory, host, port, backlog=256):
         self.address = (host, port)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((host, port))
         self.sock.listen(backlog)
         self.sock.setblocking(False)


### PR DESCRIPTION
Hello!
In first, thank you for your nice server implementation!
Now I try to use whizzer as msgpack RPC srever in production.

But I found little probelm; tcpserver not set SO_REUSEADDR
before bind socket. Without this option, user may get error
"Address Already in Use" when restarting server.

Please consider to merge this.
